### PR TITLE
Add responsive CSS styling for the previewer (#6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Markdown File Previewer</title>
+    <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
+<div class="container">
     <h1>Markdown File Previewer</h1>
     <p>Select a Markdown file to preview its rendered content.</p>
     <input type="file" id="file-input" accept=".md">
     <div id="preview"></div>
+</div>
 
     <script>
         const fileInput = document.getElementById('file-input');

--- a/style.css
+++ b/style.css
@@ -1,0 +1,106 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background-color: #f9f9f9;
+    padding: 2rem 1rem;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+}
+
+p {
+    margin-bottom: 1rem;
+    color: #555;
+}
+
+input[type="file"] {
+    display: block;
+    margin-bottom: 1.5rem;
+    padding: 0.5rem;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+#preview {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    padding: 1.5rem;
+    min-height: 200px;
+}
+
+#preview h1, #preview h2, #preview h3,
+#preview h4, #preview h5, #preview h6 {
+    margin-top: 1.2em;
+    margin-bottom: 0.6em;
+}
+
+#preview p {
+    margin-bottom: 0.8em;
+    color: inherit;
+}
+
+#preview code {
+    background: #f0f0f0;
+    padding: 0.15em 0.4em;
+    border-radius: 3px;
+    font-size: 0.9em;
+}
+
+#preview pre {
+    background: #f0f0f0;
+    padding: 1em;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin-bottom: 1em;
+}
+
+#preview pre code {
+    background: none;
+    padding: 0;
+}
+
+#preview ul, #preview ol {
+    margin-left: 1.5em;
+    margin-bottom: 0.8em;
+}
+
+#preview blockquote {
+    border-left: 4px solid #ddd;
+    padding-left: 1em;
+    color: #666;
+    margin-bottom: 0.8em;
+}
+
+#preview img {
+    max-width: 100%;
+    height: auto;
+}
+
+@media (max-width: 600px) {
+    body {
+        padding: 1rem 0.75rem;
+    }
+
+    h1 {
+        font-size: 1.4rem;
+    }
+
+    #preview {
+        padding: 1rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `style.css` with clean typography, centered max-width container, and styled preview area
- Link stylesheet in `index.html` and wrap content in `.container`
- Add responsive breakpoints for mobile (≤600px)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)