### PR TITLE
Add syntax highlighting for code blocks (#3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Markdown File Previewer</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github.min.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
 </head>
 <body>
 <div class="container">
@@ -22,6 +24,15 @@
         const fileInput = document.getElementById('file-input');
         const editor = document.getElementById('editor');
         const preview = document.getElementById('preview');
+
+        marked.setOptions({
+            highlight: function (code, lang) {
+                if (lang && hljs.getLanguage(lang)) {
+                    return hljs.highlight(code, { language: lang }).value;
+                }
+                return hljs.highlightAuto(code).value;
+            }
+        });
 
         function renderPreview() {
             preview.innerHTML = marked.parse(editor.value);


### PR DESCRIPTION
## Summary
- Include `highlight.js` and its GitHub theme via CDN
- Configure `marked` to use `hljs` for syntax highlighting in fenced code blocks
- Supports language-specific coloring (e.g. ```js, ```python) with auto-detection fallback

## Test plan
- [ ] Type a fenced code block with a language tag (e.g. ```js) — code should be syntax-highlighted
- [ ] Type a fenced code block without a language tag — auto-detection should apply coloring

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)