### PR TITLE
Add dark/light theme toggle (#4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Markdown File Previewer</title>
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github.min.css">
+    <link id="hljs-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github.min.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
 </head>
 <body>
 <div class="container">
-    <h1>Markdown File Previewer</h1>
+    <div class="header">
+        <h1>Markdown File Previewer</h1>
+        <button id="theme-toggle" title="Toggle dark/light theme">Dark</button>
+    </div>
     <p>Select a Markdown file or type Markdown below to preview its rendered content.</p>
     <input type="file" id="file-input" accept=".md">
     <div class="editor-layout">
@@ -24,6 +27,23 @@
         const fileInput = document.getElementById('file-input');
         const editor = document.getElementById('editor');
         const preview = document.getElementById('preview');
+        const themeToggle = document.getElementById('theme-toggle');
+        const hljsTheme = document.getElementById('hljs-theme');
+
+        function setTheme(dark) {
+            document.body.classList.toggle('dark', dark);
+            themeToggle.textContent = dark ? 'Light' : 'Dark';
+            hljsTheme.href = dark
+                ? 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark.min.css'
+                : 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github.min.css';
+            localStorage.setItem('theme', dark ? 'dark' : 'light');
+        }
+
+        themeToggle.addEventListener('click', function () {
+            setTheme(!document.body.classList.contains('dark'));
+        });
+
+        setTheme(localStorage.getItem('theme') === 'dark');
 
         marked.setOptions({
             highlight: function (code, lang) {

--- a/style.css
+++ b/style.css
@@ -36,9 +36,29 @@ body {
     color: #333;
 }
 
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
 h1 {
     font-size: 1.8rem;
-    margin-bottom: 0.5rem;
+}
+
+#theme-toggle {
+    padding: 0.4rem 1rem;
+    font-size: 0.9rem;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: #fff;
+    color: #333;
+    cursor: pointer;
+}
+
+#theme-toggle:hover {
+    background: #eee;
 }
 
 p {
@@ -110,6 +130,50 @@ input[type="file"] {
 #preview img {
     max-width: 100%;
     height: auto;
+}
+
+body.dark {
+    background-color: #1e1e1e;
+    color: #ddd;
+}
+
+body.dark #editor {
+    background: #2d2d2d;
+    color: #ddd;
+    border-color: #555;
+}
+
+body.dark #preview {
+    background: #2d2d2d;
+    color: #ddd;
+    border-color: #555;
+}
+
+body.dark #preview code {
+    background: #3a3a3a;
+}
+
+body.dark #preview pre {
+    background: #3a3a3a;
+}
+
+body.dark #preview blockquote {
+    border-left-color: #555;
+    color: #aaa;
+}
+
+body.dark #theme-toggle {
+    background: #333;
+    color: #ddd;
+    border-color: #555;
+}
+
+body.dark #theme-toggle:hover {
+    background: #444;
+}
+
+body.dark p {
+    color: #aaa;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Add a toggle button in the header to switch between dark and light themes
- Store theme preference in `localStorage` so it persists across sessions
- Switch highlight.js theme between `github` and `github-dark` to match

## Test plan
- [ ] Click the toggle button — page switches to dark theme
- [ ] Click again — switches back to light theme
- [ ] Refresh page — theme preference is preserved
- [ ] Add a code block — syntax highlighting theme matches current mode

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)