### PR TITLE
Add export to PDF functionality (#5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,10 @@
 <div class="container">
     <div class="header">
         <h1>Markdown File Previewer</h1>
-        <button id="theme-toggle" title="Toggle dark/light theme">Dark</button>
+        <div class="header-buttons">
+            <button id="export-pdf" title="Export preview as PDF">Export PDF</button>
+            <button id="theme-toggle" title="Toggle dark/light theme">Dark</button>
+        </div>
     </div>
     <p>Select a Markdown file or type Markdown below to preview its rendered content.</p>
     <input type="file" id="file-input" accept=".md">
@@ -44,6 +47,17 @@
         });
 
         setTheme(localStorage.getItem('theme') === 'dark');
+
+        document.getElementById('export-pdf').addEventListener('click', function () {
+            const printWindow = window.open('', '_blank');
+            printWindow.document.write('<!DOCTYPE html><html><head><title>Markdown Preview</title>');
+            printWindow.document.write('<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;line-height:1.6;max-width:800px;margin:0 auto;padding:2rem;color:#333}pre{background:#f0f0f0;padding:1em;border-radius:6px;overflow-x:auto}code{background:#f0f0f0;padding:0.15em 0.4em;border-radius:3px;font-size:0.9em}pre code{background:none;padding:0}blockquote{border-left:4px solid #ddd;padding-left:1em;color:#666}img{max-width:100%;height:auto}</style>');
+            printWindow.document.write('</head><body>');
+            printWindow.document.write(preview.innerHTML);
+            printWindow.document.write('</body></html>');
+            printWindow.document.close();
+            printWindow.print();
+        });
 
         marked.setOptions({
             highlight: function (code, lang) {

--- a/style.css
+++ b/style.css
@@ -47,7 +47,13 @@ h1 {
     font-size: 1.8rem;
 }
 
-#theme-toggle {
+.header-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+#theme-toggle,
+#export-pdf {
     padding: 0.4rem 1rem;
     font-size: 0.9rem;
     border: 1px solid #ddd;
@@ -57,7 +63,8 @@ h1 {
     cursor: pointer;
 }
 
-#theme-toggle:hover {
+#theme-toggle:hover,
+#export-pdf:hover {
     background: #eee;
 }
 
@@ -162,13 +169,15 @@ body.dark #preview blockquote {
     color: #aaa;
 }
 
-body.dark #theme-toggle {
+body.dark #theme-toggle,
+body.dark #export-pdf {
     background: #333;
     color: #ddd;
     border-color: #555;
 }
 
-body.dark #theme-toggle:hover {
+body.dark #theme-toggle:hover,
+body.dark #export-pdf:hover {
     background: #444;
 }
 


### PR DESCRIPTION
## Summary
- Add an "Export PDF" button in the header next to the theme toggle
- Opens a print-friendly window with the rendered preview and triggers the browser print dialog
- Users can save as PDF from the print dialog
- Button styled consistently and supports dark theme

## Test plan
- [ ] Type Markdown, click Export PDF — print dialog opens with rendered content
- [ ] Verify the print preview looks clean with proper styling
- [ ] Toggle dark theme — Export PDF button matches theme

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)