### PR TITLE
Add drag and drop file upload support (#7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,11 @@
             <button id="theme-toggle" title="Toggle dark/light theme">Dark</button>
         </div>
     </div>
-    <p>Select a Markdown file or type Markdown below to preview its rendered content.</p>
-    <input type="file" id="file-input" accept=".md">
+    <p>Select a Markdown file, drag and drop one, or type Markdown below to preview.</p>
+    <div id="drop-zone">
+        <p>Drag & drop a <strong>.md</strong> file here</p>
+        <input type="file" id="file-input" accept=".md">
+    </div>
     <div class="editor-layout">
         <textarea id="editor" placeholder="Type or paste Markdown here..."></textarea>
         <div id="preview"></div>
@@ -74,16 +77,35 @@
 
         editor.addEventListener('input', renderPreview);
 
-        fileInput.addEventListener('change', function (event) {
-            const file = event.target.files[0];
-            if (!file) return;
-
+        function loadFile(file) {
+            if (!file || !file.name.endsWith('.md')) return;
             const reader = new FileReader();
             reader.onload = function (e) {
                 editor.value = e.target.result;
                 renderPreview();
             };
             reader.readAsText(file);
+        }
+
+        fileInput.addEventListener('change', function (event) {
+            loadFile(event.target.files[0]);
+        });
+
+        const dropZone = document.getElementById('drop-zone');
+
+        dropZone.addEventListener('dragover', function (e) {
+            e.preventDefault();
+            dropZone.classList.add('drag-over');
+        });
+
+        dropZone.addEventListener('dragleave', function () {
+            dropZone.classList.remove('drag-over');
+        });
+
+        dropZone.addEventListener('drop', function (e) {
+            e.preventDefault();
+            dropZone.classList.remove('drag-over');
+            loadFile(e.dataTransfer.files[0]);
         });
     </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -73,9 +73,27 @@ p {
     color: #555;
 }
 
-input[type="file"] {
-    display: block;
+#drop-zone {
+    border: 2px dashed #ccc;
+    border-radius: 8px;
+    padding: 1.5rem;
+    text-align: center;
     margin-bottom: 1.5rem;
+    transition: border-color 0.2s, background-color 0.2s;
+}
+
+#drop-zone p {
+    margin-bottom: 0.5rem;
+    color: #888;
+}
+
+#drop-zone.drag-over {
+    border-color: #4a9eff;
+    background-color: rgba(74, 158, 255, 0.05);
+}
+
+input[type="file"] {
+    display: inline-block;
     padding: 0.5rem;
     font-size: 1rem;
     cursor: pointer;
@@ -183,6 +201,15 @@ body.dark #export-pdf:hover {
 
 body.dark p {
     color: #aaa;
+}
+
+body.dark #drop-zone {
+    border-color: #555;
+}
+
+body.dark #drop-zone.drag-over {
+    border-color: #4a9eff;
+    background-color: rgba(74, 158, 255, 0.1);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Add a styled drop zone with dashed border above the editor
- Visual feedback (blue highlight) when dragging a file over the drop zone
- Refactor file-loading into a shared `loadFile()` function used by both the file picker and drag-and-drop
- Only accepts `.md` files
- Drop zone styled for dark theme

## Test plan
- [ ] Drag a `.md` file onto the drop zone — file loads into editor and renders in preview
- [ ] Drag a file over the zone — border turns blue with subtle background highlight
- [ ] Drag away without dropping — highlight reverts
- [ ] Use the file picker button — still works as before
- [ ] Toggle dark theme — drop zone border adapts

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)