### PR TITLE
Add keyboard shortcuts with help overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -441,16 +441,105 @@
         }
     });
 
+    // Keyboard shortcuts help modal
+    var shortcutsModal = document.getElementById('shortcuts-modal');
+
+    function openShortcuts() {
+        shortcutsModal.style.display = '';
+    }
+
+    function closeShortcuts() {
+        shortcutsModal.style.display = 'none';
+    }
+
+    document.getElementById('shortcuts-close').addEventListener('click', closeShortcuts);
+    shortcutsModal.addEventListener('click', function (e) {
+        if (e.target === shortcutsModal) closeShortcuts();
+    });
+
+    // Download current file
+    function downloadFile() {
+        var currentTab = tabs.find(function (t) { return t.id === activeTabId; });
+        var name = currentTab && currentTab.name !== 'Untitled' ? currentTab.name : 'document.md';
+        var blob = new Blob([editor.value], { type: 'text/markdown' });
+        var a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = name;
+        a.click();
+        URL.revokeObjectURL(a.href);
+    }
+
+    // Global keyboard shortcuts
     document.addEventListener('keydown', function (e) {
         var mod = e.ctrlKey || e.metaKey;
+
+        // Search shortcuts
         if (mod && e.key === 'f') {
             e.preventDefault();
             openSearch();
+            return;
         }
         if (mod && e.key === 'h') {
             e.preventDefault();
             openSearch();
             setTimeout(function () { replaceInput.focus(); }, 50);
+            return;
+        }
+
+        // Formatting shortcuts (only when editor is focused)
+        if (mod && document.activeElement === editor) {
+            if (e.key === 'b') {
+                e.preventDefault();
+                toolbarActions.bold();
+                return;
+            }
+            if (e.key === 'i') {
+                e.preventDefault();
+                toolbarActions.italic();
+                return;
+            }
+            if (e.key === 'k') {
+                e.preventDefault();
+                toolbarActions.link();
+                return;
+            }
+            if (e.shiftKey && (e.key === 'C' || e.key === 'c')) {
+                e.preventDefault();
+                toolbarActions.code();
+                return;
+            }
+        }
+
+        // Download
+        if (mod && e.key === 's') {
+            e.preventDefault();
+            downloadFile();
+            return;
+        }
+
+        // Fullscreen toggle
+        if (mod && e.shiftKey && (e.key === 'F' || e.key === 'f')) {
+            e.preventDefault();
+            toggleFullscreen(fullscreenTarget ? fullscreenTarget : 'editor');
+            return;
+        }
+
+        // Help overlay
+        if (mod && e.key === '/') {
+            e.preventDefault();
+            if (shortcutsModal.style.display === 'none') {
+                openShortcuts();
+            } else {
+                closeShortcuts();
+            }
+            return;
+        }
+
+        // Escape
+        if (e.key === 'Escape') {
+            if (shortcutsModal.style.display !== 'none') {
+                closeShortcuts();
+            }
         }
     });
 

--- a/index.html
+++ b/index.html
@@ -162,6 +162,34 @@
     </div>
 </div>
 
+<div id="shortcuts-modal" class="modal-overlay" style="display:none;" role="dialog" aria-label="Keyboard shortcuts">
+    <div class="modal">
+        <div class="modal-header">
+            <h2>Keyboard Shortcuts</h2>
+            <button type="button" id="shortcuts-close" class="modal-close" aria-label="Close">&times;</button>
+        </div>
+        <div class="modal-body">
+            <div class="shortcut-group">
+                <h3>Formatting</h3>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>B</kbd><span>Bold</span></div>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>I</kbd><span>Italic</span></div>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>K</kbd><span>Insert link</span></div>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd><span>Inline code</span></div>
+            </div>
+            <div class="shortcut-group">
+                <h3>Actions</h3>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>F</kbd><span>Find</span></div>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>H</kbd><span>Find & Replace</span></div>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>S</kbd><span>Download file</span></div>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd><span>Fullscreen</span></div>
+                <div class="shortcut-row"><kbd>Ctrl</kbd>+<kbd>/</kbd><span>Show shortcuts</span></div>
+                <div class="shortcut-row"><kbd>Esc</kbd><span>Exit fullscreen / close</span></div>
+            </div>
+            <p class="shortcut-note">On Mac, use <kbd>Cmd</kbd> instead of <kbd>Ctrl</kbd></p>
+        </div>
+    </div>
+</div>
+
     <script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -872,6 +872,121 @@ input[type="file"] {
 }
 
 /* ==========================================================================
+   Shortcuts Modal
+   ========================================================================== */
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 8px 32px var(--color-shadow-lg);
+    width: 420px;
+    max-width: 90vw;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-4) var(--space-5);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.modal-header h2 {
+    font-size: var(--font-size-lg);
+    font-weight: 700;
+    color: var(--color-text-primary);
+    margin: 0;
+}
+
+.modal-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    font-size: 20px;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.modal-close:hover {
+    background: var(--color-btn-hover);
+    color: var(--color-text-primary);
+}
+
+.modal-body {
+    padding: var(--space-4) var(--space-5);
+}
+
+.shortcut-group {
+    margin-bottom: var(--space-4);
+}
+
+.shortcut-group h3 {
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-2);
+}
+
+.shortcut-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-1) 0;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+}
+
+.shortcut-row span {
+    color: var(--color-text-primary);
+}
+
+kbd {
+    display: inline-block;
+    padding: 2px 6px;
+    font-family: var(--font-sans);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    color: var(--color-text-primary);
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    box-shadow: 0 1px 0 var(--color-border);
+    line-height: 1.4;
+}
+
+.shortcut-note {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+    margin-top: var(--space-3);
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--color-border);
+}
+
+/* ==========================================================================
    Scrollbar Styling
    ========================================================================== */
 


### PR DESCRIPTION
## Summary
- Formatting shortcuts: Ctrl+B (bold), Ctrl+I (italic), Ctrl+K (link), Ctrl+Shift+C (code)
- Action shortcuts: Ctrl+S (download), Ctrl+F (find), Ctrl+H (replace), Ctrl+Shift+F (fullscreen)
- Ctrl+/ opens a keyboard shortcuts reference modal
- All shortcuts work with Cmd on Mac

## Test plan
- [ ] Test each formatting shortcut in the editor
- [ ] Ctrl+S downloads the current file
- [ ] Ctrl+/ opens and closes the shortcuts modal
- [ ] Escape closes the modal
- [ ] Verify modal styling in dark theme

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)